### PR TITLE
fix: improve game FPS

### DIFF
--- a/lib/entities/top_view/top_view.dart
+++ b/lib/entities/top_view/top_view.dart
@@ -9,6 +9,9 @@ import 'package:flutter/material.dart';
 import '../../flolfenstein_3d_game.dart';
 import '../../wall.dart';
 
+final _whitePaint = Paint()..color = Colors.white;
+final _greyPaint = Paint()..color = Colors.grey;
+
 class TopView extends Entity with HasGameRef<Flolfenstein3DGame> {
   TopView() : super(behaviors: [MovementBehavior()]);
 
@@ -207,13 +210,11 @@ class TopView extends Entity with HasGameRef<Flolfenstein3DGame> {
 
   @override
   void render(Canvas canvas) {
-    var whitePaint = Paint()..color = Colors.white;
-
     for (final wall in walls) {
       canvas.drawLine(
         wall.origin.toOffset() / 2,
         (wall.origin + wall.direction).toOffset() / 2,
-        whitePaint,
+        _whitePaint,
       );
     }
 
@@ -267,7 +268,7 @@ class TopView extends Entity with HasGameRef<Flolfenstein3DGame> {
         canvas.drawLine(
           gameRef.origin.toOffset() / 2,
           nearestIntersection.toOffset() / 2,
-          Paint()..color = Colors.grey,
+          _greyPaint,
         );
         if (nearestDistance <= 1000) {
           var dir = nearestIntersection - gameRef.origin;


### PR DESCRIPTION
Currently, whilst playing the game the FPS drop below 60. This PR aims to improve so.

In order to keep FPS high we need to avoid the creation of new dart objects inside any code that is run inside the game loop. This PR moves the Paint creation outside the render method, which allows to hit 60FPS more consistently. 

The same principle can be applied to the Vector being made inside the render method.

https://user-images.githubusercontent.com/44524995/188752458-ec8b8eb7-fdac-49a7-9577-c0a7a8069d1a.mp4

